### PR TITLE
Path name fix, toLowerCase added

### DIFF
--- a/code/core/src/level/tools/TileTextureFactory.java
+++ b/code/core/src/level/tools/TileTextureFactory.java
@@ -2,11 +2,13 @@ package level.tools;
 
 import tools.Point;
 
+import java.util.Locale;
+
 public class TileTextureFactory {
 
     public static String findTexture(
             LevelElement e, DesignLabel l, LevelElement[][] layout, Point p) {
-        String path = l.name() + "/";
+        String path = l.name().toLowerCase(Locale.ROOT) + "/";
 
         if (e == LevelElement.FLOOR) path += "floor/floor_1";
         else if (e == LevelElement.EXIT) path += "floor/floor_ladder";


### PR DESCRIPTION
DesignLabel#name() gibt zum Beispiel "DEFAULT" zurück. Bei Windows ist das kein Problem, aber Linux ist case sensitive und findet den Texturpfad deshalb nicht. D. h., wir brauchen noch ein toLowerCase.