### PR TITLE
Add Tobi to License.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021-2022 André Matutat, Carsten Gips
+Copyright (c) 2021-2022 André Matutat, Tobias Grothe, Carsten Gips
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Tobias ist mit einer der Haupt-Contributors und sollte direkt im License.md (und im Readme.md, wenn es mal soweit ist) erwähnt werden.