### PR TITLE
Fix nexus-staging plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,7 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: |
-          gradle publish
-          ./gradlew closeAndReleaseRepository
+        run: ./gradlew publish closeAndReleaseRepository
         working-directory: code
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -156,6 +156,4 @@ javadoc {
 nexusStaging {
     // required only for projects registered in Sonatype after 2021-02-24
     serverUrl = "https://s01.oss.sonatype.org/service/local/"
-    // optional if packageGroup == project.getGroup()
-    packageGroup = "io.github.pm-dungeon"
 }


### PR DESCRIPTION
Es trat folgender Fehler auf:

```
FAILURE: Build failed with an exception.
> Task :closeRepository FAILED

GET request failed. 401: , body: <empty>
* What went wrong:
1 actionable task: 1 executed
Execution failed for task ':closeRepository'.
> 401: , body: <empty>
```

Ich denke, das lag dran, dass `publish closeAndReleaseRepository` nicht zusammen aufgerufen wurde.
