### PR TITLE
Workflow: Upload jar files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,17 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
       - name: Publish package
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        run: ./gradlew jar
         working-directory: code
-        env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      - uses: AButler/upload-release-assets@v2.0
+        with:
+          files: 'code/build/libs/*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Publish package
+#        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+#        working-directory: code
+#        env:
+#          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+#          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+#          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+#          PASSPHRASE: ${{ secrets.PASSPHRASE }}


### PR DESCRIPTION
Fixes #167 

Verwendete Action: https://github.com/AButler/upload-release-assets

Wir müssen bitte einmal ausprobieren, ob das mit einem "Dummy-Release" funktioniert (approve, merge, new release...). Wenn es funktioniert, kommentiere ich in einem nächsten PR die Release-Action wieder ein.