### PR TITLE
CI: Änderung des in GH-Actions verwendeten JDK

### DIFF
--- a/.github/workflows/github_ci.yml
+++ b/.github/workflows/github_ci.yml
@@ -17,7 +17,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: Validate Gradle wrapper
                 uses: gradle/wrapper-validation-action@v1
             -   name: Build with Gradle
@@ -38,7 +38,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: JUnit
                 run: ./gradlew test
                 working-directory: code
@@ -59,7 +59,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: SpotBugs
                 run: |
                     ./gradlew spotbugsMain
@@ -82,7 +82,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: Checkstyle
                 run: ./gradlew check
                 working-directory: code
@@ -102,7 +102,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: Spotless
                 run: ./gradlew spotlessJavaCheck
                 working-directory: code

--- a/.github/workflows/publish_github.yml
+++ b/.github/workflows/publish_github.yml
@@ -12,7 +12,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: Validate Gradle wrapper
                 uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
             -   name: Build the jar file

--- a/.github/workflows/publish_maven.yml
+++ b/.github/workflows/publish_maven.yml
@@ -12,7 +12,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '17'
-                    distribution: 'adopt'
+                    distribution: 'temurin'
             -   name: Validate Gradle wrapper
                 uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
             -   name: Publish package to MavenCentral


### PR DESCRIPTION
Fixes #190

Ich habe das JDK in GH-Actions auf das Temurin Open JDK umgestellt, da das Adopt Open JDK keine Updates mehr bekommt.