### PR TITLE
LevelLoader

### DIFF
--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -7,14 +7,6 @@ import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
 import com.google.gson.Gson;
-import level.elements.astar.TileHeuristic;
-import level.elements.graph.Node;
-import level.elements.room.Room;
-import level.elements.room.Tile;
-import level.tools.Coordinate;
-import level.tools.DesignLabel;
-import level.tools.LevelElement;
-
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -22,6 +14,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import level.elements.astar.TileHeuristic;
+import level.elements.graph.Node;
+import level.elements.room.Room;
+import level.elements.room.Tile;
+import level.tools.Coordinate;
+import level.tools.DesignLabel;
+import level.tools.LevelElement;
 
 /**
  * A level is a set of connect rooms to play in.

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -6,9 +6,7 @@ import com.badlogic.gdx.ai.pfa.GraphPath;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import com.google.gson.Gson;
 import level.elements.astar.TileHeuristic;
 import level.elements.graph.Node;
 import level.elements.room.Room;
@@ -16,6 +14,14 @@ import level.elements.room.Tile;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 /**
  * A level is a set of connect rooms to play in.
@@ -377,5 +383,30 @@ public class Level implements IndexedGraph<Tile> {
     @Override
     public Array<Connection<Tile>> getConnections(Tile fromNode) {
         return fromNode.getConnections();
+    }
+
+    /**
+     * Converts Level in JSON.
+     *
+     * @return Level as JSON
+     */
+    public String toJSON() {
+        return new Gson().toJson(this);
+    }
+
+    /**
+     * Writes down this level in a json.
+     *
+     * @param path Where to save.
+     */
+    public void writeToJSON(String path) {
+        try {
+            BufferedWriter writer =
+                    new BufferedWriter(new FileWriter(path, StandardCharsets.UTF_8));
+            writer.write(toJSON());
+            writer.close();
+        } catch (IOException e) {
+            System.out.println("File" + path + " not found");
+        }
     }
 }

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -7,13 +7,6 @@ import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
 import com.google.gson.Gson;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
 import level.elements.astar.TileHeuristic;
 import level.elements.graph.Node;
 import level.elements.room.Room;
@@ -21,6 +14,14 @@ import level.elements.room.Tile;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 /**
  * A level is a set of connect rooms to play in.
@@ -399,11 +400,9 @@ public class Level implements IndexedGraph<Tile> {
      * @param path Where to save.
      */
     public void writeToJSON(String path) {
-        try {
-            BufferedWriter writer =
-                    new BufferedWriter(new FileWriter(path, StandardCharsets.UTF_8));
+        try (BufferedWriter writer =
+                new BufferedWriter(new FileWriter(path, StandardCharsets.UTF_8))) {
             writer.write(toJSON());
-            writer.close();
         } catch (IOException e) {
             System.out.println("File" + path + " not found");
         }

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -15,7 +15,7 @@ import level.tools.LevelElement;
  */
 public class Tile {
 
-    private final Array<Connection<Tile>> connections = new Array<>();
+    transient private final Array<Connection<Tile>> connections = new Array<>();
     private final Coordinate globalPosition;
     private String texture;
     private LevelElement e;

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -2,11 +2,12 @@ package level.elements.room;
 
 import com.badlogic.gdx.ai.pfa.Connection;
 import com.badlogic.gdx.utils.Array;
-import java.util.ArrayList;
-import java.util.List;
 import level.elements.astar.TileConnection;
 import level.tools.Coordinate;
 import level.tools.LevelElement;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A Tile is a field of the level.
@@ -15,8 +16,8 @@ import level.tools.LevelElement;
  */
 public class Tile {
 
-    transient private final Array<Connection<Tile>> connections = new Array<>();
     private final Coordinate globalPosition;
+    private transient Array<Connection<Tile>> connections = new Array<>();
     private String texture;
     private LevelElement e;
     private int index;
@@ -81,6 +82,7 @@ public class Tile {
      * @param to Tile to connect with.
      */
     public void addConnection(Tile to) {
+        if (connections == null) connections = new Array<>();
         connections.add(new TileConnection(this, to));
     }
 

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -2,12 +2,11 @@ package level.elements.room;
 
 import com.badlogic.gdx.ai.pfa.Connection;
 import com.badlogic.gdx.utils.Array;
+import java.util.ArrayList;
+import java.util.List;
 import level.elements.astar.TileConnection;
 import level.tools.Coordinate;
 import level.tools.LevelElement;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A Tile is a field of the level.

--- a/code/core/src/level/generator/LevelLoader/LevelLoader.java
+++ b/code/core/src/level/generator/LevelLoader/LevelLoader.java
@@ -3,6 +3,10 @@ package level.generator.LevelLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import level.elements.Level;
+import level.generator.IGenerator;
+import tools.Constants;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -10,9 +14,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
-import level.elements.Level;
-import level.generator.IGenerator;
-import tools.Constants;
 
 public class LevelLoader implements IGenerator {
 
@@ -27,9 +28,7 @@ public class LevelLoader implements IGenerator {
 
     public Level loadLevel(String path) {
         Type levelType = new TypeToken<Level>() {}.getType();
-        JsonReader reader = null;
-        try {
-            reader = new JsonReader(new FileReader(path, StandardCharsets.UTF_8));
+        try (JsonReader reader = new JsonReader(new FileReader(path, StandardCharsets.UTF_8))) {
             Level level = new Gson().fromJson(reader, levelType);
             level.makeConnections();
             return level;

--- a/code/core/src/level/generator/LevelLoader/LevelLoader.java
+++ b/code/core/src/level/generator/LevelLoader/LevelLoader.java
@@ -3,10 +3,6 @@ package level.generator.LevelLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
-import level.elements.Level;
-import level.generator.IGenerator;
-import tools.Constants;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -14,6 +10,9 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
+import level.elements.Level;
+import level.generator.IGenerator;
+import tools.Constants;
 
 public class LevelLoader implements IGenerator {
 

--- a/code/core/src/level/generator/LevelLoader/LevelLoader.java
+++ b/code/core/src/level/generator/LevelLoader/LevelLoader.java
@@ -3,6 +3,10 @@ package level.generator.LevelLoader;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import level.elements.Level;
+import level.generator.IGenerator;
+import tools.Constants;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -10,9 +14,6 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
-import level.elements.Level;
-import level.generator.IGenerator;
-import tools.Constants;
 
 public class LevelLoader implements IGenerator {
 
@@ -25,12 +26,14 @@ public class LevelLoader implements IGenerator {
         return loadLevel(levelFile.getPath());
     }
 
-    private Level loadLevel(String path) {
+    public Level loadLevel(String path) {
         Type levelType = new TypeToken<Level>() {}.getType();
         JsonReader reader = null;
         try {
             reader = new JsonReader(new FileReader(path, StandardCharsets.UTF_8));
-            return new Gson().fromJson(reader, levelType);
+            Level level = new Gson().fromJson(reader, levelType);
+            level.makeConnections();
+            return level;
         } catch (FileNotFoundException e) {
             System.out.println("File not found.");
             e.printStackTrace();


### PR DESCRIPTION
Fixes #217 Fixes #166

- `Tile#connections` sind jetzt mit dem `transient` Flag markiert. Dadurch kommt es zu keiner unendlichen Rekursion in gson. 
- Mit `Level#writeToJSON` können direkt in einer JSON-Datei abgespeichert werden
- Mit `Level#toJSON` kann man das aktuelle Level als JSON-String bekommen (brauchen die Studis später).- 
- Der `LevelLoader` kann jetzt Level laden. 
- Damit `Tile#connections` wieder gefüllt wird, ruft der `LevelLoader` die entsprechende Methode in `Level` auf. 
    - daher auch die `null` Prüfung in `Tile`, wenn ein `Tile` aus einer JSON eingelesen wird, ist das Ding `null` 


