### PR TITLE
getGlobalPosition() vereinfacht

### DIFF
--- a/code/checkstyle-config/checks.xml
+++ b/code/checkstyle-config/checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <!--    This configuration file is intended for later use and customization.    -->
 <module name="Checker">
     <module name="TreeWalker">

--- a/code/core/src/level/LevelAPI.java
+++ b/code/core/src/level/LevelAPI.java
@@ -53,7 +53,7 @@ public class LevelAPI {
                     if (t.getLevelElement() != LevelElement.SKIP)
                         painter.draw(
                                 t.getTexture(),
-                                new Point(t.getGlobalPosition().x, t.getGlobalPosition().y),
+                                new Point(t.getCoordinate().x, t.getCoordinate().y),
                                 batch);
                 }
     }

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
 import com.google.gson.Gson;
+import interfaces.IEntity;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -249,7 +250,7 @@ public class Level implements IndexedGraph<Tile> {
         for (Room r : rooms) {
             for (int y = 0; y < r.getLayout().length; y++)
                 for (int x = 0; x < r.getLayout()[0].length; x++)
-                    if (r.getLayout()[y][x].getGlobalPosition().equals(globalPoint))
+                    if (r.getLayout()[y][x].getCoordinate().equals(globalPoint))
                         return r.getLayout()[y][x];
         }
         return null;
@@ -265,7 +266,7 @@ public class Level implements IndexedGraph<Tile> {
         for (Room r : rooms) {
             for (int y = 0; y < r.getLayout().length; y++)
                 for (int x = 0; x < r.getLayout()[0].length; x++)
-                    if (r.getLayout()[y][x].getGlobalPosition().equals(globalPoint)) return r;
+                    if (r.getLayout()[y][x].getCoordinate().equals(globalPoint)) return r;
         }
         return null;
     }
@@ -343,28 +344,24 @@ public class Level implements IndexedGraph<Tile> {
 
         // upperTile
         Coordinate upper =
-                new Coordinate(
-                        checkTile.getGlobalPosition().x, checkTile.getGlobalPosition().y + 1);
+                new Coordinate(checkTile.getCoordinate().x, checkTile.getCoordinate().y + 1);
         Tile upperTile = getTileAt(upper);
         if (upperTile != null && upperTile.isAccessible()) checkTile.addConnection(upperTile);
 
         // lowerTile
         Coordinate lower =
-                new Coordinate(
-                        checkTile.getGlobalPosition().x, checkTile.getGlobalPosition().y - 1);
+                new Coordinate(checkTile.getCoordinate().x, checkTile.getCoordinate().y - 1);
         Tile lowerTile = getTileAt(lower);
         if (lowerTile != null && lowerTile.isAccessible()) checkTile.addConnection(lowerTile);
 
         // leftTile
         Coordinate left =
-                new Coordinate(
-                        checkTile.getGlobalPosition().x - 1, checkTile.getGlobalPosition().y);
+                new Coordinate(checkTile.getCoordinate().x - 1, checkTile.getCoordinate().y);
         Tile leftTile = getTileAt(left);
         if (leftTile != null && leftTile.isAccessible()) checkTile.addConnection(leftTile);
         // rightTile
         Coordinate right =
-                new Coordinate(
-                        checkTile.getGlobalPosition().x + 1, checkTile.getGlobalPosition().y);
+                new Coordinate(checkTile.getCoordinate().x + 1, checkTile.getCoordinate().y);
         Tile rightTile = getTileAt(right);
         if (rightTile != null && rightTile.isAccessible()) checkTile.addConnection(rightTile);
     }
@@ -382,6 +379,16 @@ public class Level implements IndexedGraph<Tile> {
     @Override
     public Array<Connection<Tile>> getConnections(Tile fromNode) {
         return fromNode.getConnections();
+    }
+
+    /**
+     * Checks if the passed entity is on the tile to the next level.
+     *
+     * @param entity entity to check for.
+     * @return if the passed entity is on the tile to the next level
+     */
+    public boolean isOnEndTile(IEntity entity) {
+        return entity.getPosition().toCoordinate().equals(getEndTile().getCoordinate());
     }
 
     /**

--- a/code/core/src/level/elements/astar/TileConnection.java
+++ b/code/core/src/level/elements/astar/TileConnection.java
@@ -20,10 +20,10 @@ public class TileConnection implements Connection<Tile> {
         this.to = to;
         this.cost =
                 Vector2.dst(
-                        from.getGlobalPosition().x,
-                        from.getGlobalPosition().y,
-                        to.getGlobalPosition().x,
-                        to.getGlobalPosition().y);
+                        from.getCoordinate().x,
+                        from.getCoordinate().y,
+                        to.getCoordinate().x,
+                        to.getCoordinate().y);
     }
 
     @Override

--- a/code/core/src/level/elements/astar/TileHeuristic.java
+++ b/code/core/src/level/elements/astar/TileHeuristic.java
@@ -17,9 +17,9 @@ public class TileHeuristic implements Heuristic<Tile> {
     @Override
     public float estimate(Tile start, Tile goal) {
         return Vector2.dst2(
-                start.getGlobalPosition().x,
-                start.getGlobalPosition().y,
-                goal.getGlobalPosition().x,
-                goal.getGlobalPosition().y);
+                start.getCoordinate().x,
+                start.getCoordinate().y,
+                goal.getCoordinate().x,
+                goal.getCoordinate().y);
     }
 }

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -102,7 +102,7 @@ public class Tile {
             directions.add(Direction.E);
         } else if (globalPosition.x > goal.getCoordinate().x) {
             directions.add(Direction.W);
-        } else if (globalPosition.y < goal.globalPosition.y) {
+        } else if (globalPosition.y < goal.getGlobalPosition().y) {
             directions.add(Direction.N);
         } else if (globalPosition.y > goal.globalPosition.y) {
             directions.add(Direction.S);

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -55,7 +55,7 @@ public class Tile {
         return texture;
     }
 
-    public Coordinate getGlobalPosition() {
+    public Coordinate getCoordinate() {
         return globalPosition;
     }
 
@@ -98,9 +98,9 @@ public class Tile {
      */
     public Direction[] directionTo(Tile goal) {
         List<Direction> directions = new ArrayList<>();
-        if (globalPosition.x < goal.getGlobalPosition().x) {
+        if (globalPosition.x < goal.getCoordinate().x) {
             directions.add(Direction.E);
-        } else if (globalPosition.x > goal.getGlobalPosition().x) {
+        } else if (globalPosition.x > goal.getCoordinate().x) {
             directions.add(Direction.W);
         } else if (globalPosition.y < goal.globalPosition.y) {
             directions.add(Direction.N);

--- a/code/core/src/level/elements/room/Tile.java
+++ b/code/core/src/level/elements/room/Tile.java
@@ -102,9 +102,9 @@ public class Tile {
             directions.add(Direction.E);
         } else if (globalPosition.x > goal.getCoordinate().x) {
             directions.add(Direction.W);
-        } else if (globalPosition.y < goal.getGlobalPosition().y) {
+        } else if (globalPosition.y < goal.getCoordinate().y) {
             directions.add(Direction.N);
-        } else if (globalPosition.y > goal.globalPosition.y) {
+        } else if (globalPosition.y > goal.getCoordinate().y) {
             directions.add(Direction.S);
         }
         return directions.toArray(new Direction[0]);

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -6,7 +6,6 @@ org.gradle.jvmargs=-Xms128m -Xmx2048m \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-
 # The "add-exports" options are a workaround to use the "google-java-format" plugin with Java 17 and Gradle 7.2.
 # See also here:
 # https://github.com/google/google-java-format#jdk-16


### PR DESCRIPTION
Fixes #200

- Um Verwirrung durch die Benennung der Methode zu vermeiden, wurde `Tile#getGlobalPosition` in `Tile#getCoordinate` umbenannt.
-  `Level` wurde um die Methode `boolean isOnEndTile(IEntity entity)` erweitert. Die Methode gibt `true` zurück, wenn die Entität auf dem End-Tile steht. Bei dem vergleich der Positionen werden Nachkommastellen abgeschnitten. 
    -  In #200 haben wir noch davon gesprochen, die Methode in `LevelAPI` hinzuzufügen. Da der `Hero` aber eher das Level kennen wird und nicht die LevelAPI, finde ich es so angenehmer zu verwenden. 
- In #200 wurde `Comparable` zwischen `Point` und `Coodinate` besprochen. Durch `isOnEndTile` sollte es dafür keinen Bedarf mehr geben. Daher wurde es in diesen PR nicht integriert (YAGNI).  