### PR TITLE
update version number

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.pm-dungeon"
-version = "2.0.0"
+version = "3.0.0"
 ext {
     appName = "pmdungeon"
     gdxVersion = "1.10.0"


### PR DESCRIPTION
Für den neuen Release.
Wir hatten Änderungen in der API gemacht, daher sollten wir jetzt bei `3.0.0` sein.
