### PR TITLE
rename getTexture in getTexturePath

### DIFF
--- a/code/core/src/basiselements/Animatable.java
+++ b/code/core/src/basiselements/Animatable.java
@@ -22,7 +22,7 @@ public abstract class Animatable extends Entity {
     public abstract Animation getActiveAnimation();
 
     @Override
-    public String getTexture() {
-        return getActiveAnimation().getNextAnimationTexture();
+    public String getTexturePath() {
+        return getActiveAnimation().getNextAnimationTexturePath();
     }
 }

--- a/code/core/src/basiselements/Entity.java
+++ b/code/core/src/basiselements/Entity.java
@@ -33,7 +33,7 @@ public abstract class Entity {
     public abstract Point getPosition();
 
     /** @return the (current) Texture-Path of the object */
-    public abstract String getTexture();
+    public abstract String getTexturePath();
 
     /** Each drawable should use this <code>Painter</code> to draw itself. */
     public Painter getPainter() {
@@ -42,6 +42,6 @@ public abstract class Entity {
 
     /** Draws this instance on the batch. */
     public void draw() {
-        getPainter().draw(getTexture(), getPosition(), getBatch());
+        getPainter().draw(getTexturePath(), getPosition(), getBatch());
     }
 }

--- a/code/core/src/basiselements/HUDElement.java
+++ b/code/core/src/basiselements/HUDElement.java
@@ -51,6 +51,7 @@ public abstract class HUDElement {
      * @param yScaling y-scale
      */
     public void drawWithScaling(float xScaling, float yScaling) {
-        getPainter().drawWithScaling(xScaling, yScaling, getTexturePath(), getPosition(), getBatch());
+        getPainter()
+                .drawWithScaling(xScaling, yScaling, getTexturePath(), getPosition(), getBatch());
     }
 }

--- a/code/core/src/basiselements/HUDElement.java
+++ b/code/core/src/basiselements/HUDElement.java
@@ -32,7 +32,7 @@ public abstract class HUDElement {
     public abstract Point getPosition();
 
     /** @return the (current) Texture-Path of the object */
-    public abstract String getTexture();
+    public abstract String getTexturePath();
 
     /** Each drawable should use this <code>Painter</code> to draw itself. */
     public HUDPainter getPainter() {
@@ -41,7 +41,7 @@ public abstract class HUDElement {
 
     /** Draws this instance on the batch. */
     public void draw() {
-        getPainter().draw(getTexture(), getPosition(), getBatch());
+        getPainter().draw(getTexturePath(), getPosition(), getBatch());
     }
 
     /**
@@ -51,6 +51,6 @@ public abstract class HUDElement {
      * @param yScaling y-scale
      */
     public void drawWithScaling(float xScaling, float yScaling) {
-        getPainter().drawWithScaling(xScaling, yScaling, getTexture(), getPosition(), getBatch());
+        getPainter().drawWithScaling(xScaling, yScaling, getTexturePath(), getPosition(), getBatch());
     }
 }

--- a/code/core/src/graphic/Animation.java
+++ b/code/core/src/graphic/Animation.java
@@ -41,7 +41,7 @@ public class Animation {
      *
      * @return The texture of the next animation step (draw this).
      */
-    public String getNextAnimationTexture() {
+    public String getNextAnimationTexturePath() {
         String stringToReturn = animationFrames.get(currentFrameIndex);
         frameTimeCounter = (frameTimeCounter + 1) % frameTime;
         if (frameTimeCounter == 0) {

--- a/code/core/src/graphic/HUDPainter.java
+++ b/code/core/src/graphic/HUDPainter.java
@@ -7,30 +7,26 @@ import textures.TextureMap;
 import tools.Constants;
 import tools.Point;
 
-/**
- * Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es.
- */
+/** Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es. */
 public class HUDPainter {
     private final TextureMap textureMap = new TextureMap();
 
-    /**
-     * Draws the instance based on its position.
-     */
+    /** Draws the instance based on its position. */
     public void draw(String texturePath, Point position, SpriteBatch batch) {
         Texture texture = textureMap.getTexture(texturePath);
         Sprite sprite = new Sprite(texture);
 
         // set up scaling of textures
         sprite.setSize(
-            texture.getWidth() / Constants.DEFAULT_ZOOM_FACTOR,
-            texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
+                texture.getWidth() / Constants.DEFAULT_ZOOM_FACTOR,
+                texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
 
         // where to draw the sprite
         sprite.setPosition(
-            position.x,
-            Constants.WINDOW_HEIGHT
-                - position.y
-                - texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
+                position.x,
+                Constants.WINDOW_HEIGHT
+                        - position.y
+                        - texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
 
         // need to be called before drawing
         batch.begin();
@@ -40,11 +36,9 @@ public class HUDPainter {
         batch.end();
     }
 
-    /**
-     * Draws the instance based on its position with default offset and specific scaling.
-     */
+    /** Draws the instance based on its position with default offset and specific scaling. */
     public void drawWithScaling(
-        float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
+            float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
         Texture texture = textureMap.getTexture(texturePath);
         Sprite sprite = new Sprite(texture);
 
@@ -53,7 +47,7 @@ public class HUDPainter {
 
         // where to draw the sprite
         sprite.setPosition(
-            position.x, Constants.WINDOW_HEIGHT - position.y - texture.getHeight() * yScaling);
+                position.x, Constants.WINDOW_HEIGHT - position.y - texture.getHeight() * yScaling);
 
         // need to be called before drawing
         batch.begin();

--- a/code/core/src/graphic/HUDPainter.java
+++ b/code/core/src/graphic/HUDPainter.java
@@ -7,26 +7,30 @@ import textures.TextureMap;
 import tools.Constants;
 import tools.Point;
 
-/** Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es. */
+/**
+ * Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es.
+ */
 public class HUDPainter {
     private final TextureMap textureMap = new TextureMap();
 
-    /** Draws the instance based on its position. */
-    public void draw(String texture, Point position, SpriteBatch batch) {
-        Texture texture1 = textureMap.getTexture(texture);
-        Sprite sprite = new Sprite(texture1);
+    /**
+     * Draws the instance based on its position.
+     */
+    public void draw(String texturePath, Point position, SpriteBatch batch) {
+        Texture texture = textureMap.getTexture(texturePath);
+        Sprite sprite = new Sprite(texture);
 
         // set up scaling of textures
         sprite.setSize(
-                texture1.getWidth() / Constants.DEFAULT_ZOOM_FACTOR,
-                texture1.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
+            texture.getWidth() / Constants.DEFAULT_ZOOM_FACTOR,
+            texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
 
         // where to draw the sprite
         sprite.setPosition(
-                position.x,
-                Constants.WINDOW_HEIGHT
-                        - position.y
-                        - texture1.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
+            position.x,
+            Constants.WINDOW_HEIGHT
+                - position.y
+                - texture.getHeight() / Constants.DEFAULT_ZOOM_FACTOR);
 
         // need to be called before drawing
         batch.begin();
@@ -36,18 +40,20 @@ public class HUDPainter {
         batch.end();
     }
 
-    /** Draws the instance based on its position with default offset and specific scaling. */
+    /**
+     * Draws the instance based on its position with default offset and specific scaling.
+     */
     public void drawWithScaling(
-            float xScaling, float yScaling, String texture, Point position, SpriteBatch batch) {
-        Texture texture1 = textureMap.getTexture(texture);
-        Sprite sprite = new Sprite(texture1);
+        float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
+        Texture texture = textureMap.getTexture(texturePath);
+        Sprite sprite = new Sprite(texture);
 
         // set up scaling of textures
-        sprite.setSize(texture1.getWidth() * xScaling, texture1.getHeight() * yScaling);
+        sprite.setSize(texture.getWidth() * xScaling, texture.getHeight() * yScaling);
 
         // where to draw the sprite
         sprite.setPosition(
-                position.x, Constants.WINDOW_HEIGHT - position.y - texture1.getHeight() * yScaling);
+            position.x, Constants.WINDOW_HEIGHT - position.y - texture.getHeight() * yScaling);
 
         // need to be called before drawing
         batch.begin();

--- a/code/core/src/graphic/Painter.java
+++ b/code/core/src/graphic/Painter.java
@@ -6,7 +6,9 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import textures.TextureMap;
 import tools.Point;
 
-/** Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es. */
+/**
+ * Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es.
+ */
 public class Painter {
     private final DungeonCamera camera;
     private final TextureMap textureMap = new TextureMap();
@@ -20,17 +22,19 @@ public class Painter {
         this.camera = camera;
     }
 
-    /** Draws the instance based on its position. */
+    /**
+     * Draws the instance based on its position.
+     */
     public void draw(
-            float xOffset,
-            float yOffset,
-            float xScaling,
-            float yScaling,
-            String texture,
-            Point position,
-            SpriteBatch batch) {
+        float xOffset,
+        float yOffset,
+        float xScaling,
+        float yScaling,
+        String texturePath,
+        Point position,
+        SpriteBatch batch) {
         if (camera.isPointInFrustum(position.x, position.y)) {
-            Sprite sprite = new Sprite(textureMap.getTexture(texture));
+            Sprite sprite = new Sprite(textureMap.getTexture(texturePath));
             // set up scaling of textures
             sprite.setSize(xScaling, yScaling);
             // where to draw the sprite
@@ -45,38 +49,44 @@ public class Painter {
         }
     }
 
-    /** Draws the instance based on its position with default offset and default scaling. */
-    public void draw(String texture, Point position, SpriteBatch batch) {
+    /**
+     * Draws the instance based on its position with default offset and default scaling.
+     */
+    public void draw(String texturePath, Point position, SpriteBatch batch) {
         // the concrete offset values are best guesses
-        Texture t = textureMap.getTexture(texture);
+        Texture t = textureMap.getTexture(texturePath);
 
         draw(
-                -0.85f,
-                -0.5f,
-                1,
-                ((float) t.getHeight() / (float) t.getWidth()),
-                texture,
-                position,
-                batch);
+            -0.85f,
+            -0.5f,
+            1,
+            ((float) t.getHeight() / (float) t.getWidth()),
+            texturePath,
+            position,
+            batch);
     }
 
-    /** Draws the instance based on its position with default scaling and specific offset. */
+    /**
+     * Draws the instance based on its position with default scaling and specific offset.
+     */
     public void draw(
-            float xOffset, float yOffset, String texture, Point position, SpriteBatch batch) {
-        Texture t = textureMap.getTexture(texture);
+        float xOffset, float yOffset, String texturePath, Point position, SpriteBatch batch) {
+        Texture t = textureMap.getTexture(texturePath);
         draw(
-                xOffset,
-                yOffset,
-                1,
-                ((float) t.getHeight() / (float) t.getWidth()),
-                texture,
-                position,
-                batch);
+            xOffset,
+            yOffset,
+            1,
+            ((float) t.getHeight() / (float) t.getWidth()),
+            texturePath,
+            position,
+            batch);
     }
 
-    /** Draws the instance based on its position with default offset and specific scaling. */
+    /**
+     * Draws the instance based on its position with default offset and specific scaling.
+     */
     public void drawWithScaling(
-            float xScaling, float yScaling, String texture, Point position, SpriteBatch batch) {
-        draw(-0.85f, -0.5f, xScaling, yScaling, texture, position, batch);
+        float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
+        draw(-0.85f, -0.5f, xScaling, yScaling, texturePath, position, batch);
     }
 }

--- a/code/core/src/graphic/Painter.java
+++ b/code/core/src/graphic/Painter.java
@@ -6,9 +6,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import textures.TextureMap;
 import tools.Point;
 
-/**
- * Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es.
- */
+/** Uses LibGDX to draw sprites on the various <code>SpriteBatch</code>es. */
 public class Painter {
     private final DungeonCamera camera;
     private final TextureMap textureMap = new TextureMap();
@@ -22,17 +20,15 @@ public class Painter {
         this.camera = camera;
     }
 
-    /**
-     * Draws the instance based on its position.
-     */
+    /** Draws the instance based on its position. */
     public void draw(
-        float xOffset,
-        float yOffset,
-        float xScaling,
-        float yScaling,
-        String texturePath,
-        Point position,
-        SpriteBatch batch) {
+            float xOffset,
+            float yOffset,
+            float xScaling,
+            float yScaling,
+            String texturePath,
+            Point position,
+            SpriteBatch batch) {
         if (camera.isPointInFrustum(position.x, position.y)) {
             Sprite sprite = new Sprite(textureMap.getTexture(texturePath));
             // set up scaling of textures
@@ -49,44 +45,38 @@ public class Painter {
         }
     }
 
-    /**
-     * Draws the instance based on its position with default offset and default scaling.
-     */
+    /** Draws the instance based on its position with default offset and default scaling. */
     public void draw(String texturePath, Point position, SpriteBatch batch) {
         // the concrete offset values are best guesses
         Texture t = textureMap.getTexture(texturePath);
 
         draw(
-            -0.85f,
-            -0.5f,
-            1,
-            ((float) t.getHeight() / (float) t.getWidth()),
-            texturePath,
-            position,
-            batch);
+                -0.85f,
+                -0.5f,
+                1,
+                ((float) t.getHeight() / (float) t.getWidth()),
+                texturePath,
+                position,
+                batch);
     }
 
-    /**
-     * Draws the instance based on its position with default scaling and specific offset.
-     */
+    /** Draws the instance based on its position with default scaling and specific offset. */
     public void draw(
-        float xOffset, float yOffset, String texturePath, Point position, SpriteBatch batch) {
+            float xOffset, float yOffset, String texturePath, Point position, SpriteBatch batch) {
         Texture t = textureMap.getTexture(texturePath);
         draw(
-            xOffset,
-            yOffset,
-            1,
-            ((float) t.getHeight() / (float) t.getWidth()),
-            texturePath,
-            position,
-            batch);
+                xOffset,
+                yOffset,
+                1,
+                ((float) t.getHeight() / (float) t.getWidth()),
+                texturePath,
+                position,
+                batch);
     }
 
-    /**
-     * Draws the instance based on its position with default offset and specific scaling.
-     */
+    /** Draws the instance based on its position with default offset and specific scaling. */
     public void drawWithScaling(
-        float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
+            float xScaling, float yScaling, String texturePath, Point position, SpriteBatch batch) {
         draw(-0.85f, -0.5f, xScaling, yScaling, texturePath, position, batch);
     }
 }

--- a/code/core/test/graphic/AnimationTest.java
+++ b/code/core/test/graphic/AnimationTest.java
@@ -38,7 +38,7 @@ class AnimationTest {
         Animation animation = new Animation(List.of("1", "2", "3"), 10);
         for (int i = 0; i < 100; i++) {
             for (int j = 0; j < 10; j++) {
-                assertEquals(String.valueOf(i % 3 + 1), animation.getNextAnimationTexture());
+                assertEquals(String.valueOf(i % 3 + 1), animation.getNextAnimationTexturePath());
             }
         }
     }


### PR DESCRIPTION
Fixes #223

Wir haben über mehrere Lösungen diskutiert:
- Anstelle von `String` einen `Path` verwenden
    - `Path` ist abstract und fordert eine eigene Implementierung
    - libGDX braucht die Funktionalitäten die `Path` liefert nicht
    => weder für das Framework noch für die Studis von Vorteil.

- Rename in `getTexturePathString` (oder ähnlich=
    - Den Return-Type im Methoden Namen zu integrieren scheint mir doppelt gemoppelt zu sein
    - `String getTexturePath` 

- Beibehalten als `String getTexture`
    - Ist doppeldeutig, Könnte auch als `Object.toString()` verstanden werden

- Daher: `String getTexturePath`
    - Logik im Framework bleibt gleich, wir fügen keine Typen hinzu die wir nicht brauchen
    - Namensgebung sollte eindeutig sein: Ich Kriege den Pfad zur Texture als String 
    - Weiterhin "easy to use" für die Studis