### PR TITLE
Update build.gradle, add buildJavadocZip task

### DIFF
--- a/.github/workflows/publish_github.yml
+++ b/.github/workflows/publish_github.yml
@@ -16,7 +16,7 @@ jobs:
             -   name: Validate Gradle wrapper
                 uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
             -   name: Build the jar file
-                run: ./gradlew jar
+                run: ./gradlew jar buildJavadocZip
                 working-directory: code
             -   name: Publish jar to GitHub
                 uses: AButler/upload-release-assets@v2.0

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.pm-dungeon"
-version = "4.0.4"
+version = "4.0.5"
 ext {
     gdxVersion = "1.10.1-SNAPSHOT"
     aiVersion = "1.8.2"
@@ -156,17 +156,17 @@ signing {
     sign publishing.publications
 }
 
-tasks.withType(Javadoc) {
+javadoc {
     // failOnError false
     options.addStringOption("Xdoclint:none", "-quiet")
     options.addStringOption("encoding", "UTF-8")
     options.addStringOption("charSet", "UTF-8")
 }
 
-javadoc {
-    if (JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption("html5", true)
-    }
+task buildJavadocZip(type: Zip, dependsOn: javadoc) {
+    from "$buildDir/docs/"
+    archiveFileName = "${project.name}-${project.version}-javadoc.zip"
+    destinationDirectory = file("$buildDir/libs/")
 }
 
 nexusPublishing {


### PR DESCRIPTION
Fixes #242 

- javadoc Tasks zusammengefasst
- buildJavadocZip Task hinzugefügt
- publish_github.yml angepasst
- neue Version