### PR TITLE
Bessere Tile-Abfragen

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.pm-dungeon"
-version = "4.0.5"
+version = "4.0.6"
 ext {
     gdxVersion = "1.10.1-SNAPSHOT"
     aiVersion = "1.8.2"

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -22,6 +22,7 @@ import level.elements.room.Tile;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
 import level.tools.LevelElement;
+import tools.Point;
 
 /**
  * A level is a set of connect rooms to play in.
@@ -377,6 +378,39 @@ public class Level implements IndexedGraph<Tile> {
     @Override
     public int getNodeCount() {
         return nodeCount;
+    }
+
+    /** @return a random Tile in the Level */
+    public Tile getRandomTile() {
+        if (new Random().nextFloat() > 0.5f) {
+            return getRandomFloorTile();
+        }
+        return getRandomWallTile();
+    }
+
+    /** @return The position of a random Tile in the Level as Point */
+    public Point getRandomTilePoint() {
+        return getRandomTile().getCoordinate().toPoint();
+    }
+
+    /** @return a random Floor-Tile in the Level */
+    public Tile getRandomFloorTile() {
+        return getRandomRoom().getRandomFloorTile();
+    }
+
+    /** @return The position of a random Floor-Tile in the Level as Point */
+    public Point getRandomFloorTilePoint() {
+        return getRandomFloorTile().getCoordinate().toPoint();
+    }
+
+    /** @return a random Wall-Tile in the Level */
+    public Tile getRandomWallTile() {
+        return getRandomRoom().getRandomWallTile();
+    }
+
+    /** @return The position of a random Wall-Tile in the Level as Point */
+    public Point getRandomWallTilePoint() {
+        return getRandomWallTile().getCoordinate().toPoint();
     }
 
     @Override

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -382,10 +382,7 @@ public class Level implements IndexedGraph<Tile> {
 
     /** @return a random Tile in the Level */
     public Tile getRandomTile() {
-        if (new Random().nextFloat() > 0.5f) {
-            return getRandomFloorTile();
-        }
-        return getRandomWallTile();
+        return getRandomRoom().getRandomTile();
     }
 
     /** @return The position of a random Tile in the Level as Point */

--- a/code/core/src/level/elements/room/Room.java
+++ b/code/core/src/level/elements/room/Room.java
@@ -88,6 +88,13 @@ public class Room {
         return copy;
     }
 
+    /** @return Random Tile in the room. */
+    public Tile getRandomTile() {
+        Random r = new Random();
+        Tile[][] layout = getLayout();
+        return layout[r.nextInt(layout.length)][r.nextInt(layout[0].length)];
+    }
+
     /** @return Random floor-tile in the room. */
     public Tile getRandomFloorTile() {
         Random r = new Random();


### PR DESCRIPTION
Fixes #244 

- jeweils eine Methode um ein zufälliges Tile, ein zufälliges Wand-Tile oder ein zufälliges Floor-Tile einfacher abzufragen
- jeweils eine Methode um die Position eines zufälligem Tiles, ein zufälligem Wand-Tiles oder ein zufälligen Floor-Tiles als `Point` einfacher abzufragen