### PR TITLE
better exit and start placment

### DIFF
--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -161,7 +161,12 @@ public class Level implements IndexedGraph<Tile> {
     /** Mark a random tile as start */
     public void setRandomStart() {
         Node startN = getRandomNode();
-        Tile startT = getRoomToNode(startN).getRandomFloorTile();
+        Tile startT;
+        do {
+            startT = getRoomToNode(startN).getRandomFloorTile();
+        } while (startT.getLevelElement() == LevelElement.PLACED_DOOR
+                && neighbourTileIsDoor(startT));
+
         setStartTile(startT);
         setStartNode(startN);
     }
@@ -169,13 +174,39 @@ public class Level implements IndexedGraph<Tile> {
     /** Mark a random tile as end */
     public void setRandomEnd() {
         Node endN = getRandomNode();
-        Tile endT = getRoomToNode(endN).getRandomFloorTile();
+        Tile endT;
+        do {
+            endT = getRoomToNode(endN).getRandomFloorTile();
+        } while (endT.getLevelElement() == LevelElement.PLACED_DOOR && neighbourTileIsDoor(endT));
         DesignLabel l = getRoomToNode(endN).getDesign();
         endT.setLevelElement(
                 LevelElement.EXIT,
                 "textures/dungeon/" + l.name().toLowerCase() + "/floor/floor_ladder.png");
         setEndTile(endT);
         setEndNode(endN);
+    }
+
+    private boolean neighbourTileIsDoor(Tile tile) {
+        Coordinate tc = tile.getCoordinate();
+        Tile neighbour = getTileAt(new Coordinate(tc.x - 1, tc.y));
+        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+            return true;
+        }
+
+        neighbour = getTileAt(new Coordinate(tc.x + 1, tc.y));
+        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+            return true;
+        }
+        neighbour = getTileAt(new Coordinate(tc.x, tc.y - 1));
+        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+            return true;
+        }
+        neighbour = getTileAt(new Coordinate(tc.x, tc.y + 1));
+        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -165,7 +165,7 @@ public class Level implements IndexedGraph<Tile> {
         do {
             startT = getRoomToNode(startN).getRandomFloorTile();
         } while (startT.getLevelElement() == LevelElement.PLACED_DOOR
-                && neighbourTileIsDoor(startT));
+            || neighbourTileIsDoor(startT));
 
         setStartTile(startT);
         setStartNode(startN);
@@ -177,7 +177,7 @@ public class Level implements IndexedGraph<Tile> {
         Tile endT;
         do {
             endT = getRoomToNode(endN).getRandomFloorTile();
-        } while (endT.getLevelElement() == LevelElement.PLACED_DOOR && neighbourTileIsDoor(endT));
+        } while (endT.getLevelElement() == LevelElement.PLACED_DOOR || neighbourTileIsDoor(endT));
         DesignLabel l = getRoomToNode(endN).getDesign();
         endT.setLevelElement(
                 LevelElement.EXIT,

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -164,8 +164,7 @@ public class Level implements IndexedGraph<Tile> {
         Tile startT;
         do {
             startT = getRoomToNode(startN).getRandomFloorTile();
-        } while (startT.getLevelElement() == LevelElement.PLACED_DOOR
-            || neighbourTileIsDoor(startT));
+        } while (isDoor(startT) || neighbourTileIsDoor(startT));
 
         setStartTile(startT);
         setStartNode(startN);
@@ -177,7 +176,7 @@ public class Level implements IndexedGraph<Tile> {
         Tile endT;
         do {
             endT = getRoomToNode(endN).getRandomFloorTile();
-        } while (endT.getLevelElement() == LevelElement.PLACED_DOOR || neighbourTileIsDoor(endT));
+        } while (isDoor(endT) || neighbourTileIsDoor(endT));
         DesignLabel l = getRoomToNode(endN).getDesign();
         endT.setLevelElement(
                 LevelElement.EXIT,
@@ -189,24 +188,28 @@ public class Level implements IndexedGraph<Tile> {
     private boolean neighbourTileIsDoor(Tile tile) {
         Coordinate tc = tile.getCoordinate();
         Tile neighbour = getTileAt(new Coordinate(tc.x - 1, tc.y));
-        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+        if (isDoor(neighbour)) {
             return true;
         }
 
         neighbour = getTileAt(new Coordinate(tc.x + 1, tc.y));
-        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+        if (isDoor(neighbour)) {
             return true;
         }
         neighbour = getTileAt(new Coordinate(tc.x, tc.y - 1));
-        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+        if (isDoor(neighbour)) {
             return true;
         }
         neighbour = getTileAt(new Coordinate(tc.x, tc.y + 1));
-        if (neighbour.getLevelElement() == LevelElement.PLACED_DOOR) {
+        if (isDoor(neighbour)) {
             return true;
         }
 
         return false;
+    }
+
+    private boolean isDoor(Tile t) {
+        return t.getLevelElement() == LevelElement.PLACED_DOOR;
     }
 
     /**

--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -187,6 +187,7 @@ public class Level implements IndexedGraph<Tile> {
 
     private boolean neighbourTileIsDoor(Tile tile) {
         Coordinate tc = tile.getCoordinate();
+
         Tile neighbour = getTileAt(new Coordinate(tc.x - 1, tc.y));
         if (isDoor(neighbour)) {
             return true;
@@ -196,10 +197,12 @@ public class Level implements IndexedGraph<Tile> {
         if (isDoor(neighbour)) {
             return true;
         }
+
         neighbour = getTileAt(new Coordinate(tc.x, tc.y - 1));
         if (isDoor(neighbour)) {
             return true;
         }
+
         neighbour = getTileAt(new Coordinate(tc.x, tc.y + 1));
         if (isDoor(neighbour)) {
             return true;

--- a/code/core/src/level/generator/dungeong/roomg/RoomTemplate.java
+++ b/code/core/src/level/generator/dungeong/roomg/RoomTemplate.java
@@ -224,6 +224,6 @@ public class RoomTemplate {
     }
 
     public void useDoor(Coordinate c) {
-        layout[c.y][c.x] = LevelElement.FLOOR;
+        layout[c.y][c.x] = LevelElement.PLACED_DOOR;
     }
 }

--- a/code/core/src/level/tools/LevelElement.java
+++ b/code/core/src/level/tools/LevelElement.java
@@ -15,8 +15,10 @@ public enum LevelElement {
     WALL(1),
     /** This field is the exit-field to the next level */
     EXIT(3),
+    /** This field can be a door-field (only for use in the generator) */
+    DOOR(4),
     /** This field is a door-field */
-    DOOR(4);
+    PLACED_DOOR(5);
 
     private int value;
 

--- a/code/core/src/level/tools/TileTextureFactory.java
+++ b/code/core/src/level/tools/TileTextureFactory.java
@@ -17,7 +17,8 @@ public class TileTextureFactory {
             Coordinate position) {
         String path = design.name().toLowerCase() + "/";
         if (element == LevelElement.SKIP) path += "floor/empty";
-        else if (element == LevelElement.FLOOR) path += "floor/floor_1";
+        else if (element == LevelElement.FLOOR || element == LevelElement.PLACED_DOOR)
+            path += "floor/floor_1";
         else if (element == LevelElement.EXIT) path += "floor/floor_ladder";
         else if (element == LevelElement.DOOR) path += "floor/floor_1";
 


### PR DESCRIPTION
Fixes #https://github.com/PM-Dungeon/dungeon-starter/issues/101

Beim setzen des Start/Ende wird geprüft, ob das Feld eine Tür ist oder ob eines der benachbarten Felder eine Tür ist. Nur wenn beide Abfragen mit `false` beantwortet werden, wird der Start/ das Ende dort platziert.

Um zu prüfen ob ein `Tile` eine Tür ist (V2)
- `LevelElement.PLACED_DOOR` hinzugefügt

@cagix wo ist mein lolli? 