### PR TITLE
dont copy layout in getLayout

### DIFF
--- a/code/core/src/level/elements/room/Room.java
+++ b/code/core/src/level/elements/room/Room.java
@@ -72,7 +72,20 @@ public class Room {
      * @param layout The new layout.
      */
     public void setLayout(Tile[][] layout) {
-        this.layout = layout;
+        this.layout = copyLayout(layout);
+    }
+
+    /**
+     * Copy's an layout.
+     *
+     * @param toCopy Layout to copy.
+     * @return The copy.
+     */
+    private Tile[][] copyLayout(Tile[][] toCopy) {
+        Tile[][] copy = new Tile[layout.length][layout[0].length];
+        for (int y = 0; y < toCopy.length; y++)
+            System.arraycopy(toCopy[y], 0, copy[y], 0, toCopy[0].length);
+        return copy;
     }
 
     /** @return Random Tile in the room. */

--- a/code/core/src/level/elements/room/Room.java
+++ b/code/core/src/level/elements/room/Room.java
@@ -63,7 +63,7 @@ public class Room {
 
     /** @return A copy of the layout. */
     public Tile[][] getLayout() {
-        return copyLayout(layout);
+        return layout;
     }
 
     /**
@@ -72,20 +72,7 @@ public class Room {
      * @param layout The new layout.
      */
     public void setLayout(Tile[][] layout) {
-        this.layout = copyLayout(layout);
-    }
-
-    /**
-     * Copy's an layout.
-     *
-     * @param toCopy Layout to copy.
-     * @return The copy.
-     */
-    private Tile[][] copyLayout(Tile[][] toCopy) {
-        Tile[][] copy = new Tile[layout.length][layout[0].length];
-        for (int y = 0; y < toCopy.length; y++)
-            System.arraycopy(toCopy[y], 0, copy[y], 0, toCopy[0].length);
-        return copy;
+        this.layout = layout;
     }
 
     /** @return Random Tile in the room. */

--- a/code/core/src/level/elements/room/Room.java
+++ b/code/core/src/level/elements/room/Room.java
@@ -15,7 +15,7 @@ public class Room {
     private final DesignLabel design;
     private final Coordinate referencePointGlobal;
     private final Coordinate referencePointLocal;
-    private Tile[][] layout;
+    private final Tile[][] layout;
 
     /**
      * @param layout List of tiles that defines the layout of the room.
@@ -64,15 +64,6 @@ public class Room {
     /** @return A copy of the layout. */
     public Tile[][] getLayout() {
         return layout;
-    }
-
-    /**
-     * Set the layout of the room.
-     *
-     * @param layout The new layout.
-     */
-    public void setLayout(Tile[][] layout) {
-        this.layout = copyLayout(layout);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/PM-Dungeon/core/issues/251

Das Layout wird nun nicht mehr kopiert. Dadurch ist es aber auch nicht mehr vor Manipulation geschützt. 
