### PR TITLE
improve level ctor

### DIFF
--- a/code/core/src/level/elements/Level.java
+++ b/code/core/src/level/elements/Level.java
@@ -8,9 +8,10 @@ import com.badlogic.gdx.ai.pfa.indexed.IndexedAStarPathFinder;
 import com.badlogic.gdx.ai.pfa.indexed.IndexedGraph;
 import com.badlogic.gdx.utils.Array;
 import com.google.gson.Gson;
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import java.io.*;
+import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -45,19 +46,43 @@ public class Level implements IndexedGraph<Tile> {
     /**
      * Create a new level
      *
-     * @param nodes A list of nodes that represent the structure of the level. Each node is
+     * @param nodes A list of nodes that represent the structure of the level. Each noe is
      *     represented by a room.
      * @param rooms A list of rooms that are in this level. Each represents a node.
+     * @return The created level
      */
-    public Level(List<Node> nodes, List<Room> rooms) {
+    public static Level getLevel(List<Node> nodes, List<Room> rooms) {
+        return new Level(nodes, rooms);
+    }
+
+    /**
+     * Load a level from a json
+     *
+     * @param levelFile Json-File
+     * @return The loaded level
+     */
+    public static Level getLevel(File levelFile) {
+        return new Level(loadLevel(levelFile));
+    }
+
+    private Level(List<Node> nodes, List<Room> rooms) {
         this.nodes = nodes;
         this.rooms = rooms;
         makeConnections();
-
         setRandomEnd();
         setRandomStart();
-
         // Generate tile lookup array while initializing
+        generateTilesCache();
+    }
+
+    private Level(Level l) {
+        this.nodes = l.getNodes();
+        this.rooms = l.getRooms();
+        this.setStartNode(l.getStartNode());
+        this.setStartTile(l.getStartTile());
+        this.setEndNode(l.getEndNode());
+        this.setEndTile(l.getEndTile());
+        makeConnections();
         generateTilesCache();
     }
 
@@ -505,6 +530,21 @@ public class Level implements IndexedGraph<Tile> {
      */
     public boolean isOnEndTile(Entity entity) {
         return entity.getPosition().toCoordinate().equals(getEndTile().getCoordinate());
+    }
+
+    private static Level loadLevel(File levelFile) {
+        Type levelType = new TypeToken<Level>() {}.getType();
+        try (JsonReader reader =
+                new JsonReader(new FileReader(levelFile, StandardCharsets.UTF_8))) {
+            return new Gson().fromJson(reader, levelType);
+        } catch (FileNotFoundException e) {
+            System.out.println("File not found.");
+            e.printStackTrace();
+        } catch (IOException e) {
+            System.out.println("File may be corrupted ");
+            e.printStackTrace();
+        }
+        return null;
     }
 
     /**

--- a/code/core/src/level/generator/LevelLoader/LevelLoader.java
+++ b/code/core/src/level/generator/LevelLoader/LevelLoader.java
@@ -1,14 +1,6 @@
 package level.generator.LevelLoader;
 
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import com.google.gson.stream.JsonReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import level.elements.Level;
 import level.generator.IGenerator;
@@ -27,28 +19,6 @@ public class LevelLoader implements IGenerator {
         File[] allLevelFiles = dir.listFiles();
         assert (allLevelFiles != null && allLevelFiles.length > 0);
         File levelFile = allLevelFiles[new Random().nextInt(allLevelFiles.length)];
-        return loadLevel(levelFile.getPath());
-    }
-
-    /**
-     * Load a level from a json
-     *
-     * @param path Path to json
-     * @return loaded level
-     */
-    public Level loadLevel(String path) {
-        Type levelType = new TypeToken<Level>() {}.getType();
-        try (JsonReader reader = new JsonReader(new FileReader(path, StandardCharsets.UTF_8))) {
-            Level level = new Gson().fromJson(reader, levelType);
-            level.makeConnections();
-            return level;
-        } catch (FileNotFoundException e) {
-            System.out.println("File not found.");
-            e.printStackTrace();
-        } catch (IOException e) {
-            System.out.println("File may be corrupted ");
-            e.printStackTrace();
-        }
-        return null;
+        return Level.getLevel(levelFile);
     }
 }

--- a/code/core/src/level/generator/dummy/DummyGenerator.java
+++ b/code/core/src/level/generator/dummy/DummyGenerator.java
@@ -84,7 +84,7 @@ public class DummyGenerator implements IGenerator {
         graph.add(room2Node);
         graph.add(room3Node);
 
-        Level level = new Level(graph, roomlist);
+        Level level = Level.getLevel(graph, roomlist);
         level.setStartNode(room3Node);
         level.setStartTile(level.getRoomToNode(room3Node).getRandomFloorTile());
         level.setEndNode(room1Node);

--- a/code/core/src/level/generator/dungeong/levelg/LevelG.java
+++ b/code/core/src/level/generator/dungeong/levelg/LevelG.java
@@ -123,7 +123,7 @@ public class LevelG implements IGenerator {
             RoomTemplate template = cs.getTemplate();
             rooms.add(template.replace(replacements, cs.getGlobalPosition(), design));
         }
-        Level level = new Level(graph.getNodes(), rooms);
+        Level level = Level.getLevel(graph.getNodes(), rooms);
         if (checkIfCompletable(level)) return level;
         // in rare cases, the path to the target may be blocked.
         else return getLevel(solveSeq, graph, design);


### PR DESCRIPTION
Fügt den `LevelBuilder` hinzu. 

@cagix Hab das Pattern noch nie angewendet, aber ich glaube so müsste das aussehen. Beim Builder für die JSON Geschichte bin ich mir noch unsicher. So wie es jetzt gemacht ist, ist es irgendwie doof. Aber ich will die json auch echt nicht manuell parsen. 


*Anmerkung: Der public ctor vom Level wird aufgrund der Kompatibilität mit der Version 4.x.x noch nicht entfernt* 
