### PR TITLE
Update check style file

### DIFF
--- a/code/checkstyle-config/checks.xml
+++ b/code/checkstyle-config/checks.xml
@@ -1,12 +1,59 @@
-<?xml version="1.0"?>
-<!DOCTYPE module PUBLIC
-    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-    "https://checkstyle.org/dtds/configuration_1_3.dtd">
-<!--    This configuration file is intended for later use and customization.    -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
 <module name="Checker">
+    <property name="severity" value="warning"/>
+
     <module name="TreeWalker">
+        <module name="JavaNCSS">
+            <property name="methodMaximum" value="40"/>
+            <property name="classMaximum" value="250"/>
+            <property name="fileMaximum" value="300"/>
+        </module>
+        <module name="BooleanExpressionComplexity"/>
+        <module name="CyclomaticComplexity">
+            <property name="max" value="7"/>
+        </module>
+        <module name="ClassDataAbstractionCoupling">
+            <property name="max" value="6"/>
+        </module>
+        <module name="MethodCount">
+            <property name="maxTotal" value="10"/>
+            <property name="maxPrivate" value="10"/>
+            <property name="maxPackage" value="10"/>
+            <property name="maxProtected" value="10"/>
+            <property name="maxPublic" value="10"/>
+        </module>
+        <module name="ParameterNumber">
+            <property name="max" value="3"/>
+        </module>
+        <module name="MethodLength">
+            <property name="max" value="40"/>
+        </module>
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="lineWrappingIndentation" value="8"/>
+            <property name="caseIndent" value="4"/>
+            <property name="throwsIndent" value="4"/>
+            <property name="arrayInitIndent" value="4"/>
+        </module>
+        <module name="TypeName"/>
+        <module name="MethodName"/>
+        <module name="MemberName"/>
+        <module name="ParameterName"/>
         <module name="ConstantName"/>
-        <module name="EmptyBlock"/>
-        <module name="Indentation"/>
+        <module name="OneStatementPerLine"/>
+        <module name="MultipleVariableDeclarations"/>
+        <module name="MissingOverride"/>
+        <module name="MissingJavadocMethod"/>
+        <module name="AvoidStarImport"/>
     </module>
+
+    <module name="LineLength">
+        <property name="max" value="100"/>
+    </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="NewlineAtEndOfFile"/>
 </module>

--- a/code/checkstyle-config/checks.xml
+++ b/code/checkstyle-config/checks.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <property name="severity" value="warning"/>


### PR DESCRIPTION
Fixes #156 

(übernommen aus Lecture-Repo, markdown/coding/src/checkstyle.xml)

Es gibt aktuelle viele Warnungen. Wir sollten die Anzahl der erlaubten Methodenparameter erhöhen (aktuell 3).