### PR TITLE
Update workflow and actions

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "java"
     id "checkstyle"
     id "com.github.spotbugs" version "5.+"
-    id "com.diffplug.spotless" version "6.+"
+    id "com.diffplug.spotless" version "6.5.+"
     id "java-library"
     id "maven-publish"
     id "signing"
@@ -25,10 +25,9 @@ sourceSets.main.java.srcDirs = ["core/src/"]
 sourceSets.test.java.srcDirs = ["core/test/"]
 
 repositories {
-    mavenLocal()
     mavenCentral()
-    gradlePluginPortal()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+    gradlePluginPortal()
     google()
 }
 


### PR DESCRIPTION
Heute gab es ein Spotless-Update, das aber noch nicht im gradlePluginPortal() ist... Siehe auch https://github.com/PM-Dungeon/dungeon-starter/pull/106

- repositories Reihenfolge geändert
- mavenLocal() entfernt
- spotless Version 6.5.9 anstatt 6.6.0