### PR TITLE
Remove version number (master, 5.x)

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.pm-dungeon"
-version = "4.0.8"
+
 ext {
     // we can not use the + operator here
     gdxVersion = "1.10.1-SNAPSHOT"


### PR DESCRIPTION
Wir sollten die Versionsnummer entfernen, damit von `master` nicht versehentlich ein Release erstellt werden kann...