### PR TITLE
Hotfix for AbstractController (version4)

### DIFF
--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -144,7 +144,8 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
             @Override
             public void remove() {
-                AbstractController.super.remove(list.get(i));
+                i--;
+                AbstractController.this.remove(list.get(i));
                 list.remove(i);
             }
         };

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -178,12 +178,12 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean equals(Object o) {
-        return Objects.equals(this, o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this);
+        return super.hashCode();
     }
 
     @Override

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -119,7 +119,7 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
     /**
      * @return An ordered list of all elements in this controller.
      */
-    public List<T> toList() {
+    private List<T> toList() {
         final List<T> list = new ArrayList<>();
         for (List<T> l : layerTreeMap.values()) {
             list.addAll(l);

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -6,7 +6,6 @@ import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 /**
  * A controller manages elements of a certain type and is based on a layer system.
@@ -118,15 +117,23 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
     }
 
     /**
-     * @return An unmodifiable iterator.
+     * @return An ordered list of all elements in this controller.
      */
-    @Override
-    public Iterator<T> iterator() {
-        // creates a list copy of merged lists
+    public List<T> toList() {
         final List<T> list = new ArrayList<>();
         for (List<T> l : layerTreeMap.values()) {
             list.addAll(l);
         }
+        return list;
+    }
+
+    /**
+     * @return An iterator.
+     */
+    @Override
+    public Iterator<T> iterator() {
+        // creates a list copy of merged lists
+        final List<T> list = toList();
         return new Iterator<T>() {
             int i = 0;
 
@@ -163,14 +170,14 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public String toString() {
-        return elementHashMap.keySet().toString();
+        return toList().toString();
     }
 
     // not needed methods
     // from LinkedHashSet, HashSet, AbstractSet, AbstractCollection and Collection
     @Override
     public Spliterator<T> spliterator() {
-        return Spliterators.spliteratorUnknownSize(iterator(), Spliterator.ORDERED);
+        return toList().spliterator();
     }
 
     @Override
@@ -180,12 +187,12 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public Object[] toArray() {
-        return elementHashMap.keySet().toArray();
+        return toList().toArray();
     }
 
     @Override
     public <T1> T1[] toArray(T1[] a) {
-        return elementHashMap.keySet().toArray(a);
+        return toList().toArray(a);
     }
 
     @Override
@@ -195,7 +202,7 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public <T1> T1[] toArray(IntFunction<T1[]> generator) {
-        return stream().toArray(generator);
+        return toList().toArray(generator);
     }
 
     @Override
@@ -205,11 +212,11 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public Stream<T> stream() {
-        return StreamSupport.stream(spliterator(), false);
+        return toList().stream();
     }
 
     @Override
     public Stream<T> parallelStream() {
-        return StreamSupport.stream(spliterator(), true);
+        return toList().parallelStream();
     }
 }

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -123,13 +123,31 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
     @Override
     public Iterator<T> iterator() {
         // creates a list copy of merged lists
-        List<T> list = new ArrayList<>();
+        final List<T> list = new ArrayList<>();
         for (List<T> l : layerTreeMap.values()) {
             list.addAll(l);
         }
-        return list.iterator();
-        // will not work with PowerMock:
-        // return map.values().stream().flatMap(List::stream).toList().iterator();
+        return new Iterator<T>() {
+            int i = 0;
+
+            @Override
+            public boolean hasNext() {
+                return i < list.size();
+            }
+
+            @Override
+            public T next() {
+                T e = list.get(i);
+                i++;
+                return e;
+            }
+
+            @Override
+            public void remove() {
+                AbstractController.super.remove(list.get(i));
+                list.remove(i);
+            }
+        };
     }
 
     @Override

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -189,31 +189,8 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
-        assert (c != null);
-        boolean modified = false;
-        for (Object e : c) {
-            modified |= remove(e);
-        }
-        return modified;
-    }
-
-    @Override
     public boolean containsAll(Collection<?> c) {
         return elementHashMap.keySet().containsAll(c);
-    }
-
-    @Override
-    public boolean retainAll(Collection<?> c) {
-        assert (c != null);
-        boolean modified = false;
-        for (T e : this) {
-            if (!c.contains(e)) {
-                remove(e);
-                modified = true;
-            }
-        }
-        return modified;
     }
 
     @Override

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -58,11 +58,6 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
         return add(t, ControllerLayer.DEFAULT);
     }
 
-    @Override
-    public boolean addAll(Collection<? extends T> c) {
-        return super.addAll(c);
-    }
-
     /**
      * Adds the element with the specific layer to this controller, if it is not already added.
      *
@@ -137,13 +132,11 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
         // return map.values().stream().flatMap(List::stream).toList().iterator();
     }
 
-    // from HashSet
     @Override
     public int size() {
         return elementHashMap.size();
     }
 
-    // from Iterable
     @Override
     public void forEach(Consumer<? super T> action) {
         iterator().forEachRemaining(action);
@@ -163,7 +156,7 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public Object clone() {
-        return super.clone();
+        throw new UnsupportedOperationException("please don't use this method");
     }
 
     @Override
@@ -174,16 +167,6 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
     @Override
     public <T1> T1[] toArray(T1[] a) {
         return elementHashMap.keySet().toArray(a);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return super.equals(o);
-    }
-
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 
     @Override

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -186,7 +186,15 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        return removeAll(c);
+        Objects.requireNonNull(c);
+        boolean modified = false;
+        for (T e : this) {
+            if (!c.contains(e)) {
+                remove(e);
+                modified = true;
+            }
+        }
+        return modified;
     }
 
     @Override

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -16,8 +16,8 @@ import java.util.stream.StreamSupport;
 public abstract class AbstractController<T extends DungeonElement> extends LinkedHashSet<T>
         implements Iterable<T> {
 
-    private final TreeMap<ControllerLayer, List<T>> layerTreeMap = new TreeMap<>();
-    private final HashMap<T, List<T>> elementHashMap = new HashMap<>();
+    private final Map<ControllerLayer, List<T>> layerTreeMap = new TreeMap<>();
+    private final Map<T, List<T>> elementHashMap = new HashMap<>();
 
     /**
      * Updates all elements that are registered at this controller, removes deletable elements and

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -57,6 +57,16 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
         return add(t, ControllerLayer.DEFAULT);
     }
 
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        for (T e : c) {
+            if (!add(e)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Adds the element with the specific layer to this controller, if it is not already added.
      *
@@ -187,11 +197,6 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean containsAll(Collection<?> c) {
-        throw new UnsupportedOperationException("please don't use this method");
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends T> c) {
         throw new UnsupportedOperationException("please don't use this method");
     }
 

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -10,6 +10,9 @@ import java.util.stream.Stream;
 /**
  * A controller manages elements of a certain type and is based on a layer system.
  *
+ * <p>Layer system means: All elements are listed in ascending order according to the layers in this
+ * controller and in the order they are arranged in the layer.
+ *
  * @param <T> Type of elements to manage.
  */
 public abstract class AbstractController<T extends DungeonElement> extends LinkedHashSet<T>

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -59,12 +59,13 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean addAll(Collection<? extends T> c) {
+        boolean modified = false;
         for (T e : c) {
-            if (!add(e)) {
-                return false;
+            if (add(e)) {
+                modified = true;
             }
         }
-        return true;
+        return modified;
     }
 
     /**

--- a/code/core/src/controller/AbstractController.java
+++ b/code/core/src/controller/AbstractController.java
@@ -171,7 +171,7 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        Objects.requireNonNull(c);
+        assert (c != null);
         boolean modified = false;
         for (Object e : c) {
             modified |= remove(e);
@@ -186,7 +186,7 @@ public abstract class AbstractController<T extends DungeonElement> extends Linke
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        Objects.requireNonNull(c);
+        assert (c != null);
         boolean modified = false;
         for (T e : this) {
             if (!c.contains(e)) {

--- a/code/core/test/controller/EntityControllerTest.java
+++ b/code/core/test/controller/EntityControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import basiselements.Entity;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -164,5 +165,25 @@ public class EntityControllerTest {
         assertTrue(controller.contains(entity1));
         assertFalse(controller.contains(entity2));
         assertFalse(controller.isEmpty());
+    }
+
+    @Test
+    public void test_random() {
+        Entity e1 = Mockito.mock(Entity.class);
+        Entity e2 = Mockito.mock(Entity.class);
+        Entity e3 = Mockito.mock(Entity.class);
+        Entity e4 = Mockito.mock(Entity.class);
+        List<Entity> l1 = List.of(e1, e2, e3, e4);
+        List<Entity> l2 = List.of(e1, e4);
+        List<Entity> l3 = List.of(e4);
+
+        assertTrue(controller.addAll(l1)); // 1,2,3,4
+        assertTrue(controller.remove(e1)); // 2,3,4
+        assertTrue(controller.retainAll(l2)); // 4
+        assertFalse(controller.retainAll(l2)); // 4
+        assertFalse(controller.retainAll(l3)); // 4
+        assertFalse(controller.isEmpty());
+        assertTrue(controller.removeAll(l2)); // -
+        assertTrue(controller.isEmpty());
     }
 }

--- a/code/core/test/controller/EntityControllerTest.java
+++ b/code/core/test/controller/EntityControllerTest.java
@@ -39,9 +39,6 @@ public class EntityControllerTest {
         verify(ecSpy).isEmpty();
 
         ecSpy.update();
-        verify(ecSpy).update();
-        verify(ecSpy).iterator();
-        Mockito.verifyNoMoreInteractions(ecSpy);
         assertFalse(ecSpy.contains(entity1));
         assertFalse(ecSpy.contains(entity2));
         assertTrue(ecSpy.isEmpty());

--- a/code/core/test/controller/EntityControllerTest.java
+++ b/code/core/test/controller/EntityControllerTest.java
@@ -18,7 +18,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EntityController.class})
+@PrepareForTest({})
 public class EntityControllerTest {
     private Entity entity1, entity2;
     private EntityController controller;
@@ -183,7 +183,7 @@ public class EntityControllerTest {
         assertFalse(controller.retainAll(l2)); // 4
         assertFalse(controller.retainAll(l3)); // 4
         assertFalse(controller.isEmpty());
-        assertTrue(controller.removeAll(l2)); // -
+        assertTrue(controller.removeIf(e -> e == e4)); // -
         assertTrue(controller.isEmpty());
     }
 }

--- a/code/core/test/controller/EntityControllerTest.java
+++ b/code/core/test/controller/EntityControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import basiselements.Entity;
+import java.util.Iterator;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -184,6 +185,16 @@ public class EntityControllerTest {
         assertFalse(controller.retainAll(l3)); // 4
         assertFalse(controller.isEmpty());
         assertTrue(controller.removeIf(e -> e == e4)); // -
+        assertTrue(controller.isEmpty());
+        assertTrue(controller.addAll(l1)); // 1,2,3,4
+        for (Iterator<Entity> it = controller.iterator(); it.hasNext(); ) {
+            Entity e = it.next();
+            if (e != e4) {
+                it.remove();
+            }
+        }
+        assertFalse(controller.isEmpty());
+        assertTrue(controller.removeAll(l3));
         assertTrue(controller.isEmpty());
     }
 }

--- a/code/core/test/controller/EntityControllerTest.java
+++ b/code/core/test/controller/EntityControllerTest.java
@@ -169,7 +169,7 @@ public class EntityControllerTest {
     }
 
     @Test
-    public void test_random() {
+    public void test_listBehavior() {
         Entity e1 = Mockito.mock(Entity.class);
         Entity e2 = Mockito.mock(Entity.class);
         Entity e3 = Mockito.mock(Entity.class);


### PR DESCRIPTION
Fixes #302 

Die Methode `addAll()` kann jetzt wieder verwendet werden.