### PR TITLE
Update gson version and add dependencies checker

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -8,6 +8,8 @@ plugins {
     id "maven-publish"
     id "signing"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
+    // OWASP, Vulnerability scanner for security in dependencies, we can call: "gradlew dependencyCheckAnalyze"
+    id "org.owasp.dependencycheck" version "7.1.0.1"
 }
 
 group = "io.github.pm-dungeon"
@@ -16,7 +18,7 @@ ext {
     // we can not use the + operator here
     gdxVersion = "1.10.1-SNAPSHOT"
     aiVersion = "1.8.2"
-    gsonVersion = "2.7"
+    gsonVersion = "2.9.0"
 }
 
 sourceCompatibility = 17

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id "maven-publish"
     id "signing"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
-    // OWASP, Vulnerability scanner for security in dependencies, we can call: "gradlew dependencyCheckAnalyze"
+    // OWASP, Vulnerability scanner for security in dependencies: "./gradlew dependencyCheckAnalyze"
     id "org.owasp.dependencycheck" version "7.1.0.1"
 }
 

--- a/code/build.gradle
+++ b/code/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id "signing"
     id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
     // OWASP, Vulnerability scanner for security in dependencies: "./gradlew dependencyCheckAnalyze"
-    id "org.owasp.dependencycheck" version "7.1.0.1"
+    id "org.owasp.dependencycheck" version "7.+"
 }
 
 group = "io.github.pm-dungeon"


### PR DESCRIPTION
Dieser PR führt zwei Dinge ein:

1. Neues Plugin für den Dependency-Check wird in die Gradle-Config eingebunden
2. Update von Gson von Version 2.7 auf Version 2.9 (Gradle-Config)

Das Update der Gson-Version beseitigt die Warning bzgl. der Vulnerabiltität.


Fixes #341 fixes #343 

