### PR TITLE
Fix für Issue 357 Pathfinding Probleme mit ID 0 

### DIFF
--- a/code/core/src/level/elements/TileLevel.java
+++ b/code/core/src/level/elements/TileLevel.java
@@ -98,7 +98,7 @@ public class TileLevel implements ILevel {
                     new Coordinate(
                             checkTile.getCoordinate().x + v.x, checkTile.getCoordinate().y + v.y);
             Tile t = getTileAt(c);
-            if (t != null && t.isAccessible()) { 
+            if (t != null && t.isAccessible()) {
                 checkTile.addConnection(t);
             }
         }

--- a/code/core/src/level/elements/TileLevel.java
+++ b/code/core/src/level/elements/TileLevel.java
@@ -1,7 +1,5 @@
 package level.elements;
 
-import java.util.ArrayList;
-import java.util.List;
 import level.elements.astar.TileHeuristic;
 import level.tools.Coordinate;
 import level.tools.DesignLabel;
@@ -17,9 +15,12 @@ public class TileLevel implements ILevel {
     protected final TileHeuristic tileHeuristic = new TileHeuristic();
     protected Tile startTile;
     protected Tile endTile;
-    protected int nodeCount = 1;
+    protected int nodeCount = 0;
     protected Tile[][] layout;
 
+    private static final Coordinate CONNECTION_OFFSETS[] = {
+        new Coordinate(0, 1), new Coordinate(0, -1), new Coordinate(1, 0), new Coordinate(-1, 0),
+    };
     /**
      * Create a new level
      *
@@ -92,33 +93,13 @@ public class TileLevel implements ILevel {
      * @param checkTile Tile to check for.
      */
     protected void addConnectionsToNeighbours(Tile checkTile) {
-
-        // upperTile
-        Coordinate upper =
-                new Coordinate(checkTile.getCoordinate().x, checkTile.getCoordinate().y + 1);
-        Tile upperTile = getTileAt(upper);
-        // lowerTile
-        Coordinate lower =
-                new Coordinate(checkTile.getCoordinate().x, checkTile.getCoordinate().y - 1);
-        Tile lowerTile = getTileAt(lower);
-        // leftTile
-        Coordinate left =
-                new Coordinate(checkTile.getCoordinate().x - 1, checkTile.getCoordinate().y);
-        Tile leftTile = getTileAt(left);
-        // rightTile
-        Coordinate right =
-                new Coordinate(checkTile.getCoordinate().x + 1, checkTile.getCoordinate().y);
-        Tile rightTile = getTileAt(right);
-
-        List<Tile> neighbourTiles = new ArrayList<>();
-        neighbourTiles.add(upperTile);
-        neighbourTiles.add(lowerTile);
-        neighbourTiles.add(leftTile);
-        neighbourTiles.add(rightTile);
-
-        for (Tile n : neighbourTiles) {
-            if (n != null) {
-                checkTile.addConnection(n);
+        for (Coordinate v : CONNECTION_OFFSETS) {
+            Coordinate c =
+                    new Coordinate(
+                            checkTile.getCoordinate().x + v.x, checkTile.getCoordinate().y + v.y);
+            Tile t = getTileAt(c);
+            if (t != null && t.isAccessible()) { // <- isAccessible fehlt in dem aktuellen stand
+                checkTile.addConnection(t);
             }
         }
     }

--- a/code/core/src/level/elements/TileLevel.java
+++ b/code/core/src/level/elements/TileLevel.java
@@ -98,7 +98,7 @@ public class TileLevel implements ILevel {
                     new Coordinate(
                             checkTile.getCoordinate().x + v.x, checkTile.getCoordinate().y + v.y);
             Tile t = getTileAt(c);
-            if (t != null && t.isAccessible()) { // <- isAccessible fehlt in dem aktuellen stand
+            if (t != null && t.isAccessible()) { 
                 checkTile.addConnection(t);
             }
         }

--- a/code/core/src/level/elements/TileLevel.java
+++ b/code/core/src/level/elements/TileLevel.java
@@ -17,7 +17,7 @@ public class TileLevel implements ILevel {
     protected final TileHeuristic tileHeuristic = new TileHeuristic();
     protected Tile startTile;
     protected Tile endTile;
-    protected int nodeCount = 0;
+    protected int nodeCount = 1;
     protected Tile[][] layout;
 
     /**

--- a/code/core/test/level/TileLevelTest.java
+++ b/code/core/test/level/TileLevelTest.java
@@ -120,32 +120,32 @@ public class TileLevelTest {
     }
 
     @Test
-    public void test_findPath_withSkips(){
+    public void test_findPath_withSkips() {
         var levelElement = new LevelElement[3][2];
-        for(int i =0 ; i < 3; i++){
+        for (int i = 0; i < 3; i++) {
             levelElement[i][0] = LevelElement.SKIP;
         }
         for (int i = 0; i < 3; i++) {
             levelElement[i][1] = LevelElement.FLOOR;
         }
         var level = new TileLevel(levelElement, DesignLabel.randomDesign());
-        var start = level.getTileAt(new Coordinate(1,0));
-        var end = level.getTileAt(new Coordinate(1,2));
-        var path = level.findPath(end,start);
+        var start = level.getTileAt(new Coordinate(1, 0));
+        var end = level.getTileAt(new Coordinate(1, 2));
+        var path = level.findPath(end, start);
         assertEquals(3, path.getCount());
     }
 
     @Test
-    public void test_findPath_withoutSkips(){
+    public void test_findPath_withoutSkips() {
         var levelElement = new LevelElement[3][1];
 
         for (int i = 0; i < 3; i++) {
             levelElement[i][0] = LevelElement.FLOOR;
         }
         var level = new TileLevel(levelElement, DesignLabel.randomDesign());
-        var start = level.getTileAt(new Coordinate(0,0));
-        var end = level.getTileAt(new Coordinate(0,2));
-        var path = level.findPath(end,start);
+        var start = level.getTileAt(new Coordinate(0, 0));
+        var end = level.getTileAt(new Coordinate(0, 2));
+        var path = level.findPath(end, start);
         assertEquals(3, path.getCount());
     }
 

--- a/code/core/test/level/TileLevelTest.java
+++ b/code/core/test/level/TileLevelTest.java
@@ -203,4 +203,39 @@ public class TileLevelTest {
         }
         assertEquals(compareString.toString(), tileLevel.printLevel());
     }
+
+    @Test
+    public void test_connections(){
+        var levelElement = new LevelElement[5][3];
+        for(int i =0 ; i < 5; i++){
+            levelElement[i][0] = LevelElement.SKIP;
+            levelElement[i][2] = LevelElement.SKIP;
+        }
+        levelElement[0][1] = LevelElement.SKIP;
+        levelElement[4][1] = LevelElement.SKIP;
+        for (int i = 1; i < 4; i++) {
+            levelElement[i][1] = LevelElement.FLOOR;
+        }
+        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
+        var start = level.getTileAt(new Coordinate(1,1));
+        var end = level.getTileAt(new Coordinate(1,3));
+        var path = level.findPath(end,start);
+        assertNotEquals(0, path.getCount());
+    }
+
+    @Test
+    public void test_connections2(){
+        var levelElement = new LevelElement[3][2];
+        for(int i =0 ; i < 3; i++){
+            levelElement[i][0] = LevelElement.SKIP;
+        }
+        for (int i = 0; i < 3; i++) {
+            levelElement[i][1] = LevelElement.FLOOR;
+        }
+        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
+        var start = level.getTileAt(new Coordinate(1,0));
+        var end = level.getTileAt(new Coordinate(1,2));
+        var path = level.findPath(end,start);
+        assertEquals(3, path.getCount());
+    }
 }

--- a/code/core/test/level/TileLevelTest.java
+++ b/code/core/test/level/TileLevelTest.java
@@ -120,6 +120,36 @@ public class TileLevelTest {
     }
 
     @Test
+    public void test_findPath_withSkips(){
+        var levelElement = new LevelElement[3][2];
+        for(int i =0 ; i < 3; i++){
+            levelElement[i][0] = LevelElement.SKIP;
+        }
+        for (int i = 0; i < 3; i++) {
+            levelElement[i][1] = LevelElement.FLOOR;
+        }
+        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
+        var start = level.getTileAt(new Coordinate(1,0));
+        var end = level.getTileAt(new Coordinate(1,2));
+        var path = level.findPath(end,start);
+        assertEquals(3, path.getCount());
+    }
+
+    @Test
+    public void test_findPath_withoutSkips(){
+        var levelElement = new LevelElement[3][1];
+
+        for (int i = 0; i < 3; i++) {
+            levelElement[i][0] = LevelElement.FLOOR;
+        }
+        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
+        var start = level.getTileAt(new Coordinate(0,0));
+        var end = level.getTileAt(new Coordinate(0,2));
+        var path = level.findPath(end,start);
+        assertEquals(3, path.getCount());
+    }
+
+    @Test
     public void test_isOnEndTile() {
         Entity entity = Mockito.mock(Entity.class);
         when(entity.getPosition()).thenReturn(endTile.getCoordinate().toPoint());
@@ -202,35 +232,5 @@ public class TileLevelTest {
             compareString.append("\n");
         }
         assertEquals(compareString.toString(), tileLevel.printLevel());
-    }
-
-    @Test
-    public void test_findpath_with_skips(){
-        var levelElement = new LevelElement[3][2];
-        for(int i =0 ; i < 3; i++){
-            levelElement[i][0] = LevelElement.SKIP;
-        }
-        for (int i = 0; i < 3; i++) {
-            levelElement[i][1] = LevelElement.FLOOR;
-        }
-        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
-        var start = level.getTileAt(new Coordinate(1,0));
-        var end = level.getTileAt(new Coordinate(1,2));
-        var path = level.findPath(end,start);
-        assertEquals(3, path.getCount());
-    }
-
-    @Test
-    public void test_findpath_without_skips(){
-        var levelElement = new LevelElement[3][1];
-
-        for (int i = 0; i < 3; i++) {
-            levelElement[i][0] = LevelElement.FLOOR;
-        }
-        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
-        var start = level.getTileAt(new Coordinate(0,0));
-        var end = level.getTileAt(new Coordinate(0,2));
-        var path = level.findPath(end,start);
-        assertEquals(3, path.getCount());
     }
 }

--- a/code/core/test/level/TileLevelTest.java
+++ b/code/core/test/level/TileLevelTest.java
@@ -205,26 +205,7 @@ public class TileLevelTest {
     }
 
     @Test
-    public void test_connections(){
-        var levelElement = new LevelElement[5][3];
-        for(int i =0 ; i < 5; i++){
-            levelElement[i][0] = LevelElement.SKIP;
-            levelElement[i][2] = LevelElement.SKIP;
-        }
-        levelElement[0][1] = LevelElement.SKIP;
-        levelElement[4][1] = LevelElement.SKIP;
-        for (int i = 1; i < 4; i++) {
-            levelElement[i][1] = LevelElement.FLOOR;
-        }
-        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
-        var start = level.getTileAt(new Coordinate(1,1));
-        var end = level.getTileAt(new Coordinate(1,3));
-        var path = level.findPath(end,start);
-        assertNotEquals(0, path.getCount());
-    }
-
-    @Test
-    public void test_connections2(){
+    public void test_findpath_with_skips(){
         var levelElement = new LevelElement[3][2];
         for(int i =0 ; i < 3; i++){
             levelElement[i][0] = LevelElement.SKIP;
@@ -235,6 +216,20 @@ public class TileLevelTest {
         var level = new TileLevel(levelElement, DesignLabel.randomDesign());
         var start = level.getTileAt(new Coordinate(1,0));
         var end = level.getTileAt(new Coordinate(1,2));
+        var path = level.findPath(end,start);
+        assertEquals(3, path.getCount());
+    }
+
+    @Test
+    public void test_findpath_without_skips(){
+        var levelElement = new LevelElement[3][1];
+
+        for (int i = 0; i < 3; i++) {
+            levelElement[i][0] = LevelElement.FLOOR;
+        }
+        var level = new TileLevel(levelElement, DesignLabel.randomDesign());
+        var start = level.getTileAt(new Coordinate(0,0));
+        var end = level.getTileAt(new Coordinate(0,2));
         var path = level.findPath(end,start);
         assertEquals(3, path.getCount());
     }


### PR DESCRIPTION
fixes #357 

Es existieren Verbindungen zu nicht zugängigen Kacheln, welche die Default-ID 0 haben und mit Floor Kacheln verbunden sind. Sobald ein Weg nur über die Bodenkachel mit der ID 0 möglich ist, wird kein Weg gefunden.

Es gibt sicher einen Grund, warum Verbindungen zu nicht zugängigen Kacheln existieren. Daher muss die ID für zugängige Kacheln größer als 0 sein. Ich habe es mit meinem Starter getestet und dann versucht 2 sehr simple Tests zu erstellen, welche einmal den existierenden Fehler auslösen wird und einer der identisch aussieht und existiert um zu testen, ob das nicht nutzen der ID 0 zu einem Problem führt.

Ich war mir nicht sicher, wie die Tests benannt werden sollen. 